### PR TITLE
fix: add `exports.{import,require}.types`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ For Example, Your project `package.json` is following:
   //      but this tool add custom `package.json` to each outDir(=lib/, module/) and resolve it.
   "exports": {
     ".": {
-      "types": {
-        "import": "./module/index.d.ts",
-        "require": "./lib/index.d.ts"
+      "import": {
+        "types": "./module/index.d.ts",
+        "default": "./module/index.js"
       },
-      "import": "./module/index.js",
-      "require": "./lib/index.js",
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      },
       "default": "./lib/index.js"
     }
   }
@@ -276,12 +278,14 @@ Also, Node.js documentation describe this behavior as follows
       "types": "./lib/index.d.ts",
       "exports": {
         ".": {
-          "types": {
-            "import": "./module/index.d.ts",
-            "require": "./lib/index.d.ts"
+          "import": {
+            "types": "./module/index.d.ts",
+            "default": "./module/index.js"
           },
-          "import": "./module/index.js",
-          "require": "./lib/index.js",
+          "require": {
+            "types": "./lib/index.d.ts",
+            "default": "./lib/index.js"
+          },
           "default": "./module/index.js"
         },
         "./package.json": "./package.json"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ For Example, Your project `package.json` is following:
   //      but this tool add custom `package.json` to each outDir(=lib/, module/) and resolve it.
   "exports": {
     ".": {
-      "types": "./module/index.d.ts",
+      "types": {
+        "import": "./module/index.d.ts",
+        "require": "./lib/index.d.ts"
+      },
       "import": "./module/index.js",
       "require": "./lib/index.js",
       "default": "./lib/index.js"
@@ -273,7 +276,10 @@ Also, Node.js documentation describe this behavior as follows
       "types": "./lib/index.d.ts",
       "exports": {
         ".": {
-          "types": "./module/index.d.ts",
+          "types": {
+            "import": "./module/index.d.ts",
+            "require": "./lib/index.d.ts"
+          },
           "import": "./module/index.js",
           "require": "./lib/index.js",
           "default": "./module/index.js"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
   },
   "exports": {
     ".": {
-      "types": "./module/tsconfig-to-dual-package.d.ts",
+      "types": {
+        "import": "./module/index.d.ts",
+        "require": "./lib/index.d.ts"
+      },
       "import": "./module/tsconfig-to-dual-package.js",
       "require": "./lib/tsconfig-to-dual-package.js",
       "default": "./module/tsconfig-to-dual-package.js"

--- a/package.json
+++ b/package.json
@@ -31,12 +31,14 @@
   },
   "exports": {
     ".": {
-      "types": {
-        "import": "./module/index.d.ts",
-        "require": "./lib/index.d.ts"
+      "import": {
+        "types": "./module/tsconfig-to-dual-package.d.ts",
+        "default": "./module/tsconfig-to-dual-package.js"
       },
-      "import": "./module/tsconfig-to-dual-package.js",
-      "require": "./lib/tsconfig-to-dual-package.js",
+      "require": {
+        "types": "./lib/tsconfig-to-dual-package.d.ts",
+        "default": "./lib/tsconfig-to-dual-package.js"
+      },
       "default": "./module/tsconfig-to-dual-package.js"
     },
     "./package.json": "./package.json"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 import { parseArgs } from "node:util";
-import { tsconfigToDualPackages } from "./tsconfig-to-dual-package.js";
+import { tsconfigToDualPackages, TSConfigDualPackageOptions } from "./tsconfig-to-dual-package.js";
 
 const HELP = `
     Usage
@@ -32,17 +32,17 @@ export const createCli = () => {
         }
     });
 };
-
 export const run = async (
     cli = createCli()
 ): Promise<{ exitStatus: number; stdout: string | null; stderr: Error | null }> => {
     if (cli.values.help) {
         return { exitStatus: 0, stdout: HELP, stderr: null };
     }
-    await tsconfigToDualPackages({
+    const options: TSConfigDualPackageOptions = {
         targetTsConfigFilePaths: cli.positionals,
         cwd: cli.values.cwd ?? process.cwd()
-    });
+    };
+    await tsconfigToDualPackages(options);
     return {
         stdout: null,
         stderr: null,

--- a/src/tsconfig-to-dual-package.ts
+++ b/src/tsconfig-to-dual-package.ts
@@ -17,13 +17,11 @@ const formatDiagnostics = (diagnostics: ts.Diagnostic[]): string => {
         .join("\n");
 };
 
-export const findTsConfig = async ({
-    targetTsConfigFilePaths,
-    cwd
-}: {
+export type TSConfigDualPackageOptions = {
     targetTsConfigFilePaths?: string[];
     cwd: string;
-}) => {
+};
+export const findTsConfig = async ({ targetTsConfigFilePaths, cwd }: TSConfigDualPackageOptions) => {
     if (targetTsConfigFilePaths && targetTsConfigFilePaths.length > 0) {
         return targetTsConfigFilePaths.map((value) => {
             return path.resolve(cwd, value);
@@ -87,13 +85,7 @@ const getModuleType = (moduleKind: ts.ModuleKind) => {
     }
     throw new Error("Non-support module kind: " + moduleKind);
 };
-export const tsconfigToDualPackages = async ({
-    targetTsConfigFilePaths,
-    cwd
-}: {
-    targetTsConfigFilePaths?: string[];
-    cwd: string;
-}) => {
+export const tsconfigToDualPackages = async ({ targetTsConfigFilePaths, cwd }: TSConfigDualPackageOptions) => {
     // search tsconfig*.json
     const tsconfigFilePaths = await findTsConfig({ targetTsConfigFilePaths, cwd });
     // load tsconfig.json


### PR DESCRIPTION
I've noticed that a single `types` fields refer to CJS or ESM d.ts in dual package.
It is unnatural.

However, I cound not found which is better.

```json5
  "exports": {
    ".": {
      "import": {
        "types": "./module/index.d.ts",
        "default": "./module/index.js"
      },
      "require": {
        "types": "./lib/index.d.ts",
        "default": "./lib/index.js"
      },
      "default": "./lib/index.js"
    }
  }
```

or

```json5
  "exports": {
    ".": {
      "types": {
        "import": "./module/index.d.ts",
        "require": "./lib/index.d.ts"
      },
      "import": "./module/index.js",
      "require": "./lib/index.js",
      "default": "./lib/index.js"
    }
  }
```

I've take first pattern

## Realated

- https://github.com/microsoft/TypeScript/issues/50762
- https://github.com/pmndrs/zustand/issues/1381
- https://github.com/tajo/ladle/pull/275
  - https://www.npmjs.com/package/@ladle/react?activeTab=explore

fix #2 